### PR TITLE
xml check before parsing as xml

### DIFF
--- a/sitecore modules/Outercore.FieldTypes/VisualList/VisualList.Frame.xaml.xml.cs
+++ b/sitecore modules/Outercore.FieldTypes/VisualList/VisualList.Frame.xaml.xml.cs
@@ -258,7 +258,8 @@ namespace Outercore.FieldTypes.Carousel
                 {
                     result.Add(item);
                 }
-                else
+                //if id is not a valid Sitecore id and has at least one closing angle bracket
+		else if(!Sitecore.Data.ID.IsID(id) && id.IndexOf(">", System.StringComparison.Ordinal) > -1 )
                 {
                     // If this field used to be an Image field then the value was stored 
                     // as an XmlValue instead of just an ItemID

--- a/sitecore modules/Outercore.FieldTypes/VisualList/VisualListField.cs
+++ b/sitecore modules/Outercore.FieldTypes/VisualList/VisualListField.cs
@@ -46,7 +46,8 @@ namespace Outercore.FieldTypes.VisualList
                 {
                     results.Add((MediaItem)item);
                 }
-                else
+                //if id is not a valid Sitecore id and has at least one closing angle bracket
+				else if(!Sitecore.Data.ID.IsID(id) && id.IndexOf(">", System.StringComparison.Ordinal) > -1 )
                 {
                     // If this field used to be an Image field then the value was stored 
                     // as an XmlValue instead of just an ItemID


### PR DESCRIPTION
Added a simple check before parsing str in VisualList as xml. e.g. If the string in VisualList is the ID of an obsolete mediaitem, without this check the VisualList will throw exception. This check will avoid clogging log files with LoadXml exceptions raised when accessing GetAttribute method on XmlValue object.
