### PR TITLE
Fix issue where an item contains a comma in the display name

### DIFF
--- a/sitecore modules/Outercore.FieldTypes/FilteredMultilist/FilteredMultilistEx.cs
+++ b/sitecore modules/Outercore.FieldTypes/FilteredMultilist/FilteredMultilistEx.cs
@@ -38,9 +38,9 @@ namespace Outercore.FieldTypes
             foreach (DictionaryEntry entry in dictionary)
             {
                 Item item = entry.Value as Item;
-                if (item != null)
+                if (item != null && item.DisplayName != null)
                 {
-                    sb.Append(item.DisplayName + ",");
+                    sb.Append(item.DisplayName.Replace(",", " ") + ",");
                     sb.Append(this.GetItemValue(item) + ",");
                 }
             }


### PR DESCRIPTION
Prior to this commit, an item containing a comma in the display name would shift the key/value order.
